### PR TITLE
Remove JavaFX dependency from core pom

### DIFF
--- a/workbenchfx-core/pom.xml
+++ b/workbenchfx-core/pom.xml
@@ -303,21 +303,9 @@
         <!-- Libraries -->
         <dependency>
             <groupId>org.openjfx</groupId>
-            <artifactId>javafx-controls</artifactId>
-            <version>13</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.openjfx</groupId>
             <artifactId>javafx-swing</artifactId>
-            <version>13</version>
+            <version>11.0.2</version>
             <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.openjfx</groupId>
-            <artifactId>javafx-fxml</artifactId>
-            <version>13</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
<!--
Thanks for your contribution!
To help us review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open an issue first and wait for approval before working on it.
- [ ] The code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html).
- [ ] JavaDoc is added / changed for public methods.
- [ ] An example of the new feature is added to the [demos](https://github.com/dlemmermann/WorkbenchFX/tree/master/workbenchfx-demo/src/main/java/com/dlsc/workbenchfx).
- [ ] Documentation of the feature is included in the [README](https://github.com/dlemmermann/WorkbenchFX/blob/master/README.md).
- [ ] Tests for the changes are included.

Fixes/Resolves/Closes #76 