### PR TITLE
Update to Java 25 / JavaFX 26

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,10 +14,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v1
         with:
-          java-version: 17
+          java-version: 21
       - name: Cache SonarCloud packages
         uses: actions/cache@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,10 +14,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v1
         with:
-          java-version: 21
+          java-version: 25
       - name: Cache SonarCloud packages
         uses: actions/cache@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: 'Set up Java'
         uses: actions/setup-java@v2
         with:
-          java-version: 14
+          java-version: 17
           distribution: 'zulu'
           server-id: central
           server-username: MAVEN_USERNAME

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: 'Set up Java'
         uses: actions/setup-java@v2
         with:
-          java-version: 21
+          java-version: 25
           distribution: 'zulu'
           server-id: central
           server-username: MAVEN_USERNAME

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: 'Set up Java'
         uses: actions/setup-java@v2
         with:
-          java-version: 17
+          java-version: 21
           distribution: 'zulu'
           server-id: central
           server-username: MAVEN_USERNAME

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.4/apache-maven-3.8.4-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.0/maven-wrapper-3.1.0.jar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,29 @@
 - Java 21 is now the minimum requirement, raised from Java 11. The artifact version follows the
   supported Java release, so this line continues as `21.x` instead of `11.x`.
 - Update JavaFX from 17.0.1 to 21.0.12
+- Update SLF4J from 1.7.32 to 2.0.18. The 1.7 and 2.x bindings are not interchangeable, so
+  applications that supply their own binding have to switch to an SLF4J 2.x one — for Log4j that
+  means replacing `log4j-slf4j-impl` with `log4j-slf4j2-impl`, as the demo now does.
 
 **Implemented enhancements:**
 
 - Update Monocle to 21.0.2 to match the JavaFX version used by the headless tests
-- Resolve the JavaFX dependencies through the existing `javafx.version` property instead of
-  repeating a hardcoded version in every dependency entry
-- Update the test stack so it can read Java 21 class files: Spock 2.4 on Groovy 4.0.29,
-  JUnit 5.14.4 / Platform 1.14.4, TestFX 4.0.18, Mockito 5.23.0, Byte Buddy 1.18.11,
-  GMavenPlus 4.3.1 and Surefire 3.5.3
+- Update the test stack so it can read Java 21 class files: Spock 2.4 on Groovy 5.0,
+  JUnit 6.1.2 (Jupiter, Vintage and Platform), TestFX 4.0.18, Mockito 5.23.0,
+  Byte Buddy 1.18.11, Hamcrest 3.0, Objenesis 3.5, AssertJ 3.27.7, Awaitility 4.3.0,
+  GMavenPlus 5.1.0 and Surefire 3.5.6
+- Update the remaining libraries to their latest versions compatible with the JavaFX 21 baseline:
+  Guava 33.6.0-jre, Log4j 2.26.1, Ikonli 12.4.0, ControlsFX 11.2.3, PreferencesFX 11.19.0,
+  CalendarFX 11.12.7, GMapsFX 11.0.7 and CSSFX 11.5.1
+- Update the build plugins: Compiler 3.15.0, Source 3.4.0, Javadoc 3.12.0, Surefire 3.5.6,
+  JaCoCo 0.8.15, Exec 3.6.3 and Build Helper 3.6.1. The Javadoc plugin no longer overrides ASM
+  with 8.0.1, a version that predates and cannot read Java 21 class files, but uses 9.10.1.
+- Declare every dependency and plugin version through a property. The properties live in the
+  parent POM, except for the ones only the demo uses, which live in `workbenchfx-demo/pom.xml`.
+- Update `dlsc-maven-parent` to 1.6.0 and the Maven wrapper to 3.9.11
+- Run the JavaFX tests headless on Monocle
 - Build and release on JDK 21 in the GitHub Actions workflows
+- Document the demo applications and how to run them in `workbenchfx-demo/README.md`
 
 **Fixed bugs:**
 
@@ -25,6 +38,12 @@
   `WorkbenchModule.getIcon()`, which silently had no effect, so every mock module was named `""`
   during the tests. The name is now passed to the real constructor, and the two dead stubs are
   gone. Spock 2.4 rejects such stubs instead of ignoring them, which is how this surfaced.
+- `SelectionStripSpec` checked `instanceof Callback<SelectionStrip, StripCell<WorkbenchModule>>`.
+  The type arguments were erased at runtime and never took part in the check; Groovy 5 rejects
+  such an expression outright instead of accepting it, so the assertion now names the raw type.
+- Manage `ikonli-material-pack` alongside the other Ikonli artifacts. PreferencesFX pulls it in
+  transitively at an older version than the one the rest of the Ikonli dependencies resolve to,
+  which broke the `requireUpperBoundDeps` enforcer rule in the demo.
 
 **Known issues:**
 
@@ -35,9 +54,9 @@
   calls them. The last release with a working implementation is JavaFX 21.0.2, and the newest
   JavaFX line is affected as well, so upgrading is not a way out. In the demos this shows up when
   opening the *JFX-Central* module. See `workbenchfx-demo/README.md` for details.
-- Update `dlsc-maven-parent` to 1.6.0 and the Maven wrapper to 3.9.11
-- Run the JavaFX tests headless on Monocle
-- Document the demo applications and how to run them in `workbenchfx-demo/README.md`
+- JavaFX stays on the 21 line even though newer releases exist, because Monocle — which the
+  headless tests run on — has no release beyond 21.0.2. CalendarFX is held at 11.12.7 for the
+  same reason: 12.x requires JavaFX 23 or newer.
 
 ## [11.0.2](https://github.com/dlsc-software-consulting-gmbh/WorkbenchFX/tree/11.0.2) (2019-09-08)
 [Full Changelog](https://github.com/dlsc-software-consulting-gmbh/WorkbenchFX/compare/8.0.2...11.0.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Change Log
 
+## [17.0.0](https://github.com/dlsc-software-consulting-gmbh/WorkbenchFX/tree/17.0.0) (2026-07-26)
+[Full Changelog](https://github.com/dlsc-software-consulting-gmbh/WorkbenchFX/compare/11.3.1...17.0.0)
+
+**Breaking changes:**
+
+- Java 17 is now the minimum requirement, raised from Java 11. The artifact version follows the
+  supported Java release, so this line continues as `17.x` instead of `11.x`.
+
+**Implemented enhancements:**
+
+- Update `dlsc-maven-parent` to 1.6.0 and the Maven wrapper to 3.9.11
+- Run the JavaFX tests headless on Monocle
+- Document the demo applications and how to run them in `workbenchfx-demo/README.md`
+
 ## [11.0.2](https://github.com/dlsc-software-consulting-gmbh/WorkbenchFX/tree/11.0.2) (2019-09-08)
 [Full Changelog](https://github.com/dlsc-software-consulting-gmbh/WorkbenchFX/compare/8.0.2...11.0.2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,33 @@
 # Change Log
 
-## [17.0.0](https://github.com/dlsc-software-consulting-gmbh/WorkbenchFX/tree/17.0.0) (2026-07-26)
-[Full Changelog](https://github.com/dlsc-software-consulting-gmbh/WorkbenchFX/compare/11.3.1...17.0.0)
+## [21.0.0](https://github.com/dlsc-software-consulting-gmbh/WorkbenchFX/tree/21.0.0) (2026-07-26)
+[Full Changelog](https://github.com/dlsc-software-consulting-gmbh/WorkbenchFX/compare/11.3.1...21.0.0)
 
 **Breaking changes:**
 
-- Java 17 is now the minimum requirement, raised from Java 11. The artifact version follows the
-  supported Java release, so this line continues as `17.x` instead of `11.x`.
+- Java 21 is now the minimum requirement, raised from Java 11. The artifact version follows the
+  supported Java release, so this line continues as `21.x` instead of `11.x`.
+- Update JavaFX from 17.0.1 to 21.0.12
 
 **Implemented enhancements:**
 
+- Update Monocle to 21.0.2 to match the JavaFX version used by the headless tests
+- Resolve the JavaFX dependencies through the existing `javafx.version` property instead of
+  repeating a hardcoded version in every dependency entry
+- Update the test stack so it can read Java 21 class files: Spock 2.3 on Groovy 4.0.32,
+  JUnit 5.14.4 / Platform 1.14.4, TestFX 4.0.18, Mockito 5.23.0, Byte Buddy 1.18.11,
+  GMavenPlus 4.3.1 and Surefire 3.5.3
+- Build and release on JDK 21 in the GitHub Actions workflows
+
+**Known issues:**
+
+- WebView pages that open a WebSocket fail with
+  `UnsatisfiedLinkError: 'void com.sun.webkit.network.SocketStreamHandle.twkDidOpen(long)'`.
+  This is an upstream JavaFX problem: since 21.0.3 the bundled `libjfxwebkit` no longer
+  implements the `SocketStreamHandle` native methods, although the Java class still declares and
+  calls them. The last release with a working implementation is JavaFX 21.0.2, and the newest
+  JavaFX line is affected as well, so upgrading is not a way out. In the demos this shows up when
+  opening the *JFX-Central* module. See `workbenchfx-demo/README.md` for details.
 - Update `dlsc-maven-parent` to 1.6.0 and the Maven wrapper to 3.9.11
 - Run the JavaFX tests headless on Monocle
 - Document the demo applications and how to run them in `workbenchfx-demo/README.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Change Log
 
+## [25.0.0](https://github.com/dlsc-software-consulting-gmbh/WorkbenchFX/tree/25.0.0) (2026-07-26)
+[Full Changelog](https://github.com/dlsc-software-consulting-gmbh/WorkbenchFX/compare/21.0.0...25.0.0)
+
+**Breaking changes:**
+
+- Java 25 is now the minimum requirement, raised from Java 21. The artifact version follows the
+  supported Java release, so this line continues as `25.x` instead of `21.x`.
+- Update JavaFX from 21.0.12 to 26.0.2
+
+**Implemented enhancements:**
+
+- Drop the `org.testfx:openjfx-monocle` test dependency. Since version 26 JavaFX ships its own
+  headless Glass platform, so the headless test setup no longer needs a third-party one. The
+  Surefire configuration now selects it with `-Dglass.platform=Headless` instead of
+  `-Dglass.platform=Monocle -Dmonocle.platform=Headless`. This also unpins JavaFX, which could
+  not move past the 21 line while Monocle was needed — its last release is 21.0.2.
+- Update CalendarFX from 11.12.7 to 12.1.0, which requires JavaFX 23 or newer and was therefore
+  out of reach before
+- Build and release on JDK 25 in the GitHub Actions workflows
+- Document both supported lines in `README.md`, with a table mapping the WorkbenchFX version to
+  the Java and JavaFX versions it needs
+
+**Fixed bugs:**
+
+- Manage `commons-logging`, which CalendarFX 12.1.0 pulls in at three different versions through
+  its own dependency and through the `commons-validator` / `commons-beanutils` chain. This broke
+  the `DependencyConvergence` enforcer rule in the demo.
+
+**Known issues:**
+
+- The WebView WebSocket `UnsatisfiedLinkError` reported for 21.0.0 is still present. JavaFX 26
+  declares `twkDidOpen`, `twkDidReceiveData`, `twkDidFail` and `twkDidClose` as native methods on
+  `com.sun.webkit.network.SocketStreamHandle`, but the bundled `libjfxwebkit` implements none of
+  them. Moving to a newer JavaFX therefore does not fix it. See the 21.0.0 entry below and
+  `workbenchfx-demo/README.md` for details.
+- `testfx.headless=true` must not be set. TestFX 4.0.18 implements that flag by loading the
+  Monocle platform factory, so setting it fails with a `ClassNotFoundException` on the headless
+  JavaFX platform. Headlessness comes from `glass.platform` instead.
+- The Surefire flags have to stay in `systemPropertyVariables` and cannot move into `argLine`,
+  because `forkCount` is `0` and Surefire ignores `argLine` when it does not fork.
+
 ## [21.0.0](https://github.com/dlsc-software-consulting-gmbh/WorkbenchFX/tree/21.0.0) (2026-07-26)
 [Full Changelog](https://github.com/dlsc-software-consulting-gmbh/WorkbenchFX/compare/11.3.1...21.0.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,17 @@
 - Update Monocle to 21.0.2 to match the JavaFX version used by the headless tests
 - Resolve the JavaFX dependencies through the existing `javafx.version` property instead of
   repeating a hardcoded version in every dependency entry
-- Update the test stack so it can read Java 21 class files: Spock 2.3 on Groovy 4.0.32,
+- Update the test stack so it can read Java 21 class files: Spock 2.4 on Groovy 4.0.29,
   JUnit 5.14.4 / Platform 1.14.4, TestFX 4.0.18, Mockito 5.23.0, Byte Buddy 1.18.11,
   GMavenPlus 4.3.1 and Surefire 3.5.3
 - Build and release on JDK 21 in the GitHub Actions workflows
+
+**Fixed bugs:**
+
+- `WorkbenchSpec` stubbed the final methods `WorkbenchModule.getName()` and
+  `WorkbenchModule.getIcon()`, which silently had no effect, so every mock module was named `""`
+  during the tests. The name is now passed to the real constructor, and the two dead stubs are
+  gone. Spock 2.4 rejects such stubs instead of ignoring them, which is how this surfaced.
 
 **Known issues:**
 

--- a/README.md
+++ b/README.md
@@ -13,30 +13,12 @@
 
 To use this framework as part of your Maven build simply add the following dependency to your pom.xml file:
 
-### Java 8
+### Java 21
 ```XML
 <dependency>
   <groupId>com.dlsc.workbenchfx</groupId>
   <artifactId>workbenchfx-core</artifactId>
-  <version>8.1.0</version>
-</dependency>
-```
-
-### Java 11
-```XML
-<dependency>
-  <groupId>com.dlsc.workbenchfx</groupId>
-  <artifactId>workbenchfx-core</artifactId>
-  <version>11.1.0</version>
-</dependency>
-```
-
-### Java 17
-```XML
-<dependency>
-  <groupId>com.dlsc.workbenchfx</groupId>
-  <artifactId>workbenchfx-core</artifactId>
-  <version>17.0.0</version>
+  <version>21.0.0</version>
 </dependency>
 ```
 
@@ -44,24 +26,10 @@ To use this framework as part of your Maven build simply add the following depen
 
 To use this framework as part of your gradle build simply add the following to your build.gradle file and use the following dependency definition:
 
-### Java 8
+### Java 21
 ```groovy
 dependencies {
-    compile group: 'com.dlsc.workbenchfx', name: 'workbenchfx-core', version: '8.1.0'
-}
-```
-
-### Java 11
-```groovy
-dependencies {
-    compile group: 'com.dlsc.workbenchfx', name: 'workbenchfx-core', version: '11.1.0'
-}
-```
-
-### Java 17
-```groovy
-dependencies {
-    implementation group: 'com.dlsc.workbenchfx', name: 'workbenchfx-core', version: '17.0.0'
+    implementation group: 'com.dlsc.workbenchfx', name: 'workbenchfx-core', version: '21.0.0'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,11 +9,32 @@
 
 ![screenshot of an application created with WorkbenchFX](docs/images/workbenchFX_in_use.png) 
 
+## Versions
+
+The version of *WorkbenchFX* follows the Java release it is built for. Pick the line that matches
+the Java version of your application:
+
+| WorkbenchFX | Requires Java | Built against JavaFX |
+| --- | --- | --- |
+| `25.0.0` | 25 or later | 26 |
+| `21.0.0` | 21 or later | 21 |
+
 ## Maven
 
 To use this framework as part of your Maven build simply add the following dependency to your pom.xml file:
 
+### Java 25
+
+```XML
+<dependency>
+  <groupId>com.dlsc.workbenchfx</groupId>
+  <artifactId>workbenchfx-core</artifactId>
+  <version>25.0.0</version>
+</dependency>
+```
+
 ### Java 21
+
 ```XML
 <dependency>
   <groupId>com.dlsc.workbenchfx</groupId>
@@ -26,7 +47,16 @@ To use this framework as part of your Maven build simply add the following depen
 
 To use this framework as part of your gradle build simply add the following to your build.gradle file and use the following dependency definition:
 
+### Java 25
+
+```groovy
+dependencies {
+    implementation group: 'com.dlsc.workbenchfx', name: 'workbenchfx-core', version: '25.0.0'
+}
+```
+
 ### Java 21
+
 ```groovy
 dependencies {
     implementation group: 'com.dlsc.workbenchfx', name: 'workbenchfx-core', version: '21.0.0'

--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ To use this framework as part of your Maven build simply add the following depen
 </dependency>
 ```
 
+### Java 17
+```XML
+<dependency>
+  <groupId>com.dlsc.workbenchfx</groupId>
+  <artifactId>workbenchfx-core</artifactId>
+  <version>17.0.0</version>
+</dependency>
+```
+
 ## Gradle
 
 To use this framework as part of your gradle build simply add the following to your build.gradle file and use the following dependency definition:
@@ -46,6 +55,13 @@ dependencies {
 ```groovy
 dependencies {
     compile group: 'com.dlsc.workbenchfx', name: 'workbenchfx-core', version: '11.1.0'
+}
+```
+
+### Java 17
+```groovy
+dependencies {
+    implementation group: 'com.dlsc.workbenchfx', name: 'workbenchfx-core', version: '17.0.0'
 }
 ```
 
@@ -207,14 +223,9 @@ Note:
 - The full documentation about the module lifecycle can be found in the documentation file `workbenchfx-demo/src/main/resources/com/dlsc/workbenchfx/modules/webview/index.html`, in the section *WorkbenchModule Lifecycle*
 
 # Demos
-We created several demos to visualize the capabilities of *WorkbenchFX* in the `workbenchfx-demo` folder:
+We created several demos to visualize the capabilities of *WorkbenchFX* in the `workbenchfx-demo` folder.
 
-File                | Description
-------------------- | -----------
-`SimpleDemo.java`   | Shows the simplest usage of *WorkbenchFX* with only three modules and no optional features used
-`ExtendedDemo.java` | Shows a simple workbench application with most of the features used in a simple way.
-`CustomDemo.java`   | A workbench application which uses all features, to demonstrate the full capability of *WorkbenchFX*
-`FXMLDemo.java`     | A minimal example of how to use *WorkbenchFX* with FXML & [Scene Builder](https://gluonhq.com/products/scene-builder/)
+See [workbenchfx-demo/README.md](workbenchfx-demo/README.md) for an overview of the available demos and how to run them.
 
 # Getting started
 ## Extending the WorkbenchModule

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -25,7 +25,7 @@ project:
   license: Apache-2.0
   languages:
     java:
-      version: 17
+      version: 21
       groupId: com.dlsc.workbenchfx
       artifactId: workbenchfx-core
   extraProperties:

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -23,6 +23,11 @@ project:
   authors:
     - Dirk Lemmermann
   license: Apache-2.0
+  languages:
+    java:
+      version: 17
+      groupId: com.dlsc.workbenchfx
+      artifactId: workbenchfx-core
   extraProperties:
     inceptionYear: 2022
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.dlsc.workbenchfx</groupId>
     <artifactId>workbenchfx-parent</artifactId>
-    <version>21.0.0</version>
+    <version>25.0.0</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -16,11 +16,11 @@
     </parent>
 
     <properties>
-        <java.version>21</java.version>
-        <javafx.version>21.0.12</javafx.version>
+        <java.version>25</java.version>
+        <javafx.version>26.0.2</javafx.version>
 
         <!-- Libraries -->
-        <calendarfx.version>11.12.7</calendarfx.version>
+        <calendarfx.version>12.1.0</calendarfx.version>
         <controlsfx.version>11.2.3</controlsfx.version>
         <gmapsfx.version>11.0.7</gmapsfx.version>
         <guava.version>33.6.0-jre</guava.version>
@@ -29,6 +29,7 @@
         <preferencesfx.version>11.19.0</preferencesfx.version>
 
         <!-- Logging -->
+        <commons-logging.version>1.3.6</commons-logging.version>
         <log4j.version>2.26.1</log4j.version>
         <slf4j.version>2.0.18</slf4j.version>
 
@@ -42,7 +43,6 @@
         <junit.vintage.version>6.1.2</junit.vintage.version>
         <junit.platform.version>6.1.2</junit.platform.version>
         <mockito.version>5.23.0</mockito.version>
-        <monocle.version>21.0.2</monocle.version>
         <objenesis.version>3.5</objenesis.version>
         <spock.version>2.4-groovy-5.0</spock.version>
         <testfx.version>4.0.18</testfx.version>
@@ -225,13 +225,6 @@
                 <version>${testfx.version}</version>
             </dependency>
 
-            <!-- Monocle: headless JavaFX platform, so tests don't open windows on the desktop -->
-            <dependency>
-                <groupId>org.testfx</groupId>
-                <artifactId>openjfx-monocle</artifactId>
-                <version>${monocle.version}</version>
-            </dependency>
-
             <dependency>
                 <groupId>org.testfx</groupId>
                 <artifactId>testfx-junit5</artifactId>
@@ -279,6 +272,17 @@
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-slf4j2-impl</artifactId>
                 <version>${log4j.version}</version>
+            </dependency>
+
+            <!--
+              CalendarFX pulls this in three times at three different versions, through its own
+              dependency and through the commons-validator / commons-beanutils chain. Managed here
+              so the versions converge.
+            -->
+            <dependency>
+                <groupId>commons-logging</groupId>
+                <artifactId>commons-logging</artifactId>
+                <version>${commons-logging.version}</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,9 @@
 
     <properties>
         <ikonli.version>12.2.0</ikonli.version>
-        <java.version>11</java.version>
+        <java.version>17</java.version>
         <javafx.version>17.0.1</javafx.version>
+        <monocle.version>17.0.10</monocle.version>
         <junit.version>4.13.2</junit.version>
         <junit.jupiter.version>5.8.2</junit.jupiter.version>
         <junit.vintage.version>5.8.2</junit.vintage.version>
@@ -34,6 +35,24 @@
         <module>workbenchfx-core</module>
         <module>workbenchfx-demo</module>
     </modules>
+
+    <build>
+        <plugins>
+            <plugin>
+                <!-- the version inherited from the parent POM doesn't know about JDKs newer than 16 -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.4.1</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>extra-enforcer-rules</artifactId>
+                        <version>1.7.0</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
 
     <dependencyManagement>
         <dependencies>
@@ -181,6 +200,13 @@
                 <groupId>org.testfx</groupId>
                 <artifactId>testfx-core</artifactId>
                 <version>4.0.16-alpha</version>
+            </dependency>
+
+            <!-- Monocle: headless JavaFX platform, so tests don't open windows on the desktop -->
+            <dependency>
+                <groupId>org.testfx</groupId>
+                <artifactId>openjfx-monocle</artifactId>
+                <version>${monocle.version}</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -24,9 +24,7 @@
         <junit.jupiter.version>5.14.4</junit.jupiter.version>
         <junit.vintage.version>5.14.4</junit.vintage.version>
         <junit.platform.version>1.14.4</junit.platform.version>
-        <spock.version>2.3-groovy-4.0</spock.version>
-        <!-- Spock 2.3 pins Groovy 4.0.4, which cannot read Java 21 class files -->
-        <groovy.version>4.0.32</groovy.version>
+        <spock.version>2.4-groovy-4.0</spock.version>
         <testfx.version>4.0.18</testfx.version>
         <sonar.projectKey>dlsc-software-consulting-gmbh_WorkbenchFX</sonar.projectKey>
         <sonar.organization>dlsc-software-consulting-gmbh</sonar.organization>
@@ -168,12 +166,6 @@
                 <groupId>org.spockframework</groupId>
                 <artifactId>spock-core</artifactId>
                 <version>${spock.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.apache.groovy</groupId>
-                <artifactId>groovy</artifactId>
-                <version>${groovy.version}</version>
             </dependency>
 
             <dependency> <!-- enables mocking of classes (in addition to interfaces) -->

--- a/pom.xml
+++ b/pom.xml
@@ -16,16 +16,47 @@
     </parent>
 
     <properties>
-        <ikonli.version>12.2.0</ikonli.version>
         <java.version>21</java.version>
         <javafx.version>21.0.12</javafx.version>
-        <monocle.version>21.0.2</monocle.version>
+
+        <!-- Libraries -->
+        <calendarfx.version>11.12.7</calendarfx.version>
+        <controlsfx.version>11.2.3</controlsfx.version>
+        <gmapsfx.version>11.0.7</gmapsfx.version>
+        <guava.version>33.6.0-jre</guava.version>
+        <ikonli.version>12.4.0</ikonli.version>
+        <license4j.version>1.4.0</license4j.version>
+        <preferencesfx.version>11.19.0</preferencesfx.version>
+
+        <!-- Logging -->
+        <log4j.version>2.26.1</log4j.version>
+        <slf4j.version>2.0.18</slf4j.version>
+
+        <!-- Test -->
+        <assertj.version>3.27.7</assertj.version>
+        <awaitility.version>4.3.0</awaitility.version>
+        <bytebuddy.version>1.18.11</bytebuddy.version>
+        <hamcrest.version>3.0</hamcrest.version>
         <junit.version>4.13.2</junit.version>
-        <junit.jupiter.version>5.14.4</junit.jupiter.version>
-        <junit.vintage.version>5.14.4</junit.vintage.version>
-        <junit.platform.version>1.14.4</junit.platform.version>
-        <spock.version>2.4-groovy-4.0</spock.version>
+        <junit.jupiter.version>6.1.2</junit.jupiter.version>
+        <junit.vintage.version>6.1.2</junit.vintage.version>
+        <junit.platform.version>6.1.2</junit.platform.version>
+        <mockito.version>5.23.0</mockito.version>
+        <monocle.version>21.0.2</monocle.version>
+        <objenesis.version>3.5</objenesis.version>
+        <spock.version>2.4-groovy-5.0</spock.version>
         <testfx.version>4.0.18</testfx.version>
+
+        <!-- Build plugins -->
+        <asm.version>9.10.1</asm.version>
+        <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
+        <gmavenplus-plugin.version>5.1.0</gmavenplus-plugin.version>
+        <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
+        <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
+        <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
+        <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
+        <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
+
         <sonar.projectKey>dlsc-software-consulting-gmbh_WorkbenchFX</sonar.projectKey>
         <sonar.organization>dlsc-software-consulting-gmbh</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
@@ -63,6 +94,13 @@
             <dependency>
                 <groupId>org.kordamp.ikonli</groupId>
                 <artifactId>ikonli-materialdesign-pack</artifactId>
+                <version>${ikonli.version}</version>
+            </dependency>
+
+            <!-- Pulled in transitively by PreferencesFX; kept on the same Ikonli version as the rest -->
+            <dependency>
+                <groupId>org.kordamp.ikonli</groupId>
+                <artifactId>ikonli-material-pack</artifactId>
                 <version>${ikonli.version}</version>
             </dependency>
 
@@ -111,18 +149,18 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>31.0.1-jre</version>
+                <version>${guava.version}</version>
             </dependency>
 
             <!-- Logging -->
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>1.7.32</version>
+                <version>${slf4j.version}</version>
             </dependency>
 
             <!-- *** Test *** -->
-            <!-- JUnit 5 Testing Framework -->
+            <!-- JUnit 6 Testing Framework -->
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-api</artifactId>
@@ -151,10 +189,10 @@
             <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest</artifactId>
-                <version>2.2</version>
+                <version>${hamcrest.version}</version>
             </dependency>
 
-            <!-- JUnit 4 Engine for JUnit 5, is needed for Spock to work -->
+            <!-- JUnit 4 Engine for JUnit 6, is needed for Spock to work -->
             <dependency>
                 <groupId>org.junit.vintage</groupId>
                 <artifactId>junit-vintage-engine</artifactId>
@@ -171,13 +209,13 @@
             <dependency> <!-- enables mocking of classes (in addition to interfaces) -->
                 <groupId>net.bytebuddy</groupId>
                 <artifactId>byte-buddy</artifactId>
-                <version>1.18.11</version>
+                <version>${bytebuddy.version}</version>
             </dependency>
 
             <dependency> <!-- enables mocking of classes without default constructor (together with CGLIB) -->
                 <groupId>org.objenesis</groupId>
                 <artifactId>objenesis</artifactId>
-                <version>3.2</version>
+                <version>${objenesis.version}</version>
             </dependency>
 
             <!-- TestFX for JavaFX Testing -->
@@ -209,75 +247,75 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>5.23.0</version>
+                <version>${mockito.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
-                <version>3.21.0</version>
+                <version>${assertj.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.awaitility</groupId>
                 <artifactId>awaitility</artifactId>
-                <version>4.1.1</version>
+                <version>${awaitility.version}</version>
             </dependency>
 
             <!-- Logging -->
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-core</artifactId>
-                <version>2.17.1</version>
+                <version>${log4j.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-api</artifactId>
-                <version>2.17.1</version>
+                <version>${log4j.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-slf4j-impl</artifactId>
-                <version>2.17.1</version>
+                <artifactId>log4j-slf4j2-impl</artifactId>
+                <version>${log4j.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>com.license4j</groupId>
                 <artifactId>license4j</artifactId>
-                <version>1.4.0</version>
+                <version>${license4j.version}</version>
             </dependency>
 
             <!-- Libraries -->
             <dependency>
                 <groupId>com.dlsc.workbenchfx</groupId>
                 <artifactId>workbenchfx-core</artifactId>
-                <version>21.0.0</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>com.dlsc</groupId>
                 <artifactId>GMapsFX</artifactId>
-                <version>11.0.6</version>
+                <version>${gmapsfx.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>com.calendarfx</groupId>
                 <artifactId>view</artifactId>
-                <version>11.8.3</version>
+                <version>${calendarfx.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>com.dlsc.preferencesfx</groupId>
                 <artifactId>preferencesfx-core</artifactId>
-                <version>11.9.0</version>
+                <version>${preferencesfx.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.controlsfx</groupId>
                 <artifactId>controlsfx</artifactId>
-                <version>11.1.1</version>
+                <version>${controlsfx.version}</version>
             </dependency>
         </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.dlsc.workbenchfx</groupId>
     <artifactId>workbenchfx-parent</artifactId>
-    <version>11.3.1</version>
+    <version>17.0.0</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -250,7 +250,7 @@
             <dependency>
                 <groupId>com.dlsc.workbenchfx</groupId>
                 <artifactId>workbenchfx-core</artifactId>
-                <version>11.3.1</version>
+                <version>17.0.0</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.dlsc</groupId>
         <artifactId>dlsc-maven-parent</artifactId>
-        <version>1.0.0</version>
+        <version>1.6.0</version>
     </parent>
 
     <properties>
@@ -35,24 +35,6 @@
         <module>workbenchfx-core</module>
         <module>workbenchfx-demo</module>
     </modules>
-
-    <build>
-        <plugins>
-            <plugin>
-                <!-- the version inherited from the parent POM doesn't know about JDKs newer than 16 -->
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.4.1</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>extra-enforcer-rules</artifactId>
-                        <version>1.7.0</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
-        </plugins>
-    </build>
 
     <dependencyManagement>
         <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.dlsc.workbenchfx</groupId>
     <artifactId>workbenchfx-parent</artifactId>
-    <version>17.0.0</version>
+    <version>21.0.0</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -17,12 +17,17 @@
 
     <properties>
         <ikonli.version>12.2.0</ikonli.version>
-        <java.version>17</java.version>
-        <javafx.version>17.0.1</javafx.version>
-        <monocle.version>17.0.10</monocle.version>
+        <java.version>21</java.version>
+        <javafx.version>21.0.12</javafx.version>
+        <monocle.version>21.0.2</monocle.version>
         <junit.version>4.13.2</junit.version>
-        <junit.jupiter.version>5.8.2</junit.jupiter.version>
-        <junit.vintage.version>5.8.2</junit.vintage.version>
+        <junit.jupiter.version>5.14.4</junit.jupiter.version>
+        <junit.vintage.version>5.14.4</junit.vintage.version>
+        <junit.platform.version>1.14.4</junit.platform.version>
+        <spock.version>2.3-groovy-4.0</spock.version>
+        <!-- Spock 2.3 pins Groovy 4.0.4, which cannot read Java 21 class files -->
+        <groovy.version>4.0.32</groovy.version>
+        <testfx.version>4.0.18</testfx.version>
         <sonar.projectKey>dlsc-software-consulting-gmbh_WorkbenchFX</sonar.projectKey>
         <sonar.organization>dlsc-software-consulting-gmbh</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
@@ -66,43 +71,43 @@
             <dependency>
                 <groupId>org.openjfx</groupId>
                 <artifactId>javafx-base</artifactId>
-                <version>17.0.1</version>
+                <version>${javafx.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.openjfx</groupId>
                 <artifactId>javafx-web</artifactId>
-                <version>17.0.1</version>
+                <version>${javafx.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.openjfx</groupId>
                 <artifactId>javafx-swing</artifactId>
-                <version>17.0.1</version>
+                <version>${javafx.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.openjfx</groupId>
                 <artifactId>javafx-controls</artifactId>
-                <version>17.0.1</version>
+                <version>${javafx.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.openjfx</groupId>
                 <artifactId>javafx-fxml</artifactId>
-                <version>17.0.1</version>
+                <version>${javafx.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.openjfx</groupId>
                 <artifactId>javafx-graphics</artifactId>
-                <version>17.0.1</version>
+                <version>${javafx.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.openjfx</groupId>
                 <artifactId>javafx-media</artifactId>
-                <version>17.0.1</version>
+                <version>${javafx.version}</version>
             </dependency>
 
             <dependency>
@@ -135,7 +140,7 @@
             <dependency>
                 <groupId>org.junit.platform</groupId>
                 <artifactId>junit-platform-engine</artifactId>
-                <version>1.8.2</version>
+                <version>${junit.platform.version}</version>
                 <scope>test</scope>
             </dependency>
 
@@ -162,13 +167,19 @@
             <dependency>
                 <groupId>org.spockframework</groupId>
                 <artifactId>spock-core</artifactId>
-                <version>2.0-groovy-3.0</version>
+                <version>${spock.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.groovy</groupId>
+                <artifactId>groovy</artifactId>
+                <version>${groovy.version}</version>
             </dependency>
 
             <dependency> <!-- enables mocking of classes (in addition to interfaces) -->
                 <groupId>net.bytebuddy</groupId>
                 <artifactId>byte-buddy</artifactId>
-                <version>1.12.4</version>
+                <version>1.18.11</version>
             </dependency>
 
             <dependency> <!-- enables mocking of classes without default constructor (together with CGLIB) -->
@@ -181,7 +192,7 @@
             <dependency>
                 <groupId>org.testfx</groupId>
                 <artifactId>testfx-core</artifactId>
-                <version>4.0.16-alpha</version>
+                <version>${testfx.version}</version>
             </dependency>
 
             <!-- Monocle: headless JavaFX platform, so tests don't open windows on the desktop -->
@@ -194,19 +205,19 @@
             <dependency>
                 <groupId>org.testfx</groupId>
                 <artifactId>testfx-junit5</artifactId>
-                <version>4.0.16-alpha</version>
+                <version>${testfx.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.testfx</groupId>
                 <artifactId>testfx-spock</artifactId>
-                <version>4.0.16-alpha</version>
+                <version>${testfx.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>4.2.0</version>
+                <version>5.23.0</version>
             </dependency>
 
             <dependency>
@@ -250,7 +261,7 @@
             <dependency>
                 <groupId>com.dlsc.workbenchfx</groupId>
                 <artifactId>workbenchfx-core</artifactId>
-                <version>17.0.0</version>
+                <version>21.0.0</version>
             </dependency>
 
             <dependency>

--- a/workbenchfx-core/pom.xml
+++ b/workbenchfx-core/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.dlsc.workbenchfx</groupId>
         <artifactId>workbenchfx-parent</artifactId>
-        <version>21.0.0</version>
+        <version>25.0.0</version>
     </parent>
 
     <artifactId>workbenchfx-core</artifactId>
@@ -179,15 +179,21 @@
                     </includes>
                     <forkCount>0</forkCount>
                     <!--
-                      Run the JavaFX tests headless on the Monocle platform: no windows are opened on
-                      the desktop and the TestFX robot delivers its events to the JavaFX window
-                      instead of to whichever window currently owns the focus of the desktop.
+                      Run the JavaFX tests on the headless Glass platform that JavaFX ships since
+                      version 26: no windows are opened on the desktop and the TestFX robot delivers
+                      its events to the JavaFX window instead of to whichever window currently owns
+                      the focus of the desktop.
+
+                      Note that `testfx.headless` is deliberately not set. That flag makes TestFX
+                      load the Monocle platform factory, which would bring back the dependency on
+                      org.testfx:openjfx-monocle that this configuration replaces.
+
+                      These have to stay system properties rather than move into `argLine`, because
+                      `forkCount` is 0 above and Surefire ignores `argLine` when it does not fork.
                     -->
                     <systemPropertyVariables>
                         <testfx.robot>glass</testfx.robot>
-                        <testfx.headless>true</testfx.headless>
-                        <glass.platform>Monocle</glass.platform>
-                        <monocle.platform>Headless</monocle.platform>
+                        <glass.platform>Headless</glass.platform>
                         <prism.order>sw</prism.order>
                         <java.awt.headless>true</java.awt.headless>
                     </systemPropertyVariables>
@@ -334,12 +340,6 @@
         <dependency>
             <groupId>org.testfx</groupId>
             <artifactId>testfx-spock</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency> <!-- headless JavaFX platform, see surefire configuration -->
-            <groupId>org.testfx</groupId>
-            <artifactId>openjfx-monocle</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/workbenchfx-core/pom.xml
+++ b/workbenchfx-core/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.dlsc.workbenchfx</groupId>
         <artifactId>workbenchfx-parent</artifactId>
-        <version>11.3.1</version>
+        <version>17.0.0</version>
     </parent>
 
     <artifactId>workbenchfx-core</artifactId>

--- a/workbenchfx-core/pom.xml
+++ b/workbenchfx-core/pom.xml
@@ -178,6 +178,19 @@
                         <include>**/*Test.java</include>
                     </includes>
                     <forkCount>0</forkCount>
+                    <!--
+                      Run the JavaFX tests headless on the Monocle platform: no windows are opened on
+                      the desktop and the TestFX robot delivers its events to the JavaFX window
+                      instead of to whichever window currently owns the focus of the desktop.
+                    -->
+                    <systemPropertyVariables>
+                        <testfx.robot>glass</testfx.robot>
+                        <testfx.headless>true</testfx.headless>
+                        <glass.platform>Monocle</glass.platform>
+                        <monocle.platform>Headless</monocle.platform>
+                        <prism.order>sw</prism.order>
+                        <java.awt.headless>true</java.awt.headless>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
 
@@ -321,6 +334,12 @@
         <dependency>
             <groupId>org.testfx</groupId>
             <artifactId>testfx-spock</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency> <!-- headless JavaFX platform, see surefire configuration -->
+            <groupId>org.testfx</groupId>
+            <artifactId>openjfx-monocle</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/workbenchfx-core/pom.xml
+++ b/workbenchfx-core/pom.xml
@@ -58,7 +58,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>${maven-compiler-plugin.version}</version>
                 <configuration>
                     <release>${java.version}</release>
                     <source>${java.version}</source>
@@ -70,7 +70,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>${maven-source-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -83,7 +83,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.3.1</version>
+                <version>${maven-javadoc-plugin.version}</version>
                 <configuration>
                     <failOnError>false</failOnError>
                     <force>true</force>
@@ -123,7 +123,7 @@
                     <dependency>
                         <groupId>org.ow2.asm</groupId>
                         <artifactId>asm</artifactId>
-                        <version>8.0.1</version>
+                        <version>${asm.version}</version>
                     </dependency>
                 </dependencies>
                 <executions>
@@ -150,7 +150,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.5</version>
+                <version>${jacoco-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -170,7 +170,7 @@
             <!-- Execute Tests (JUnit / Spock) -->
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.3</version>
+                <version>${maven-surefire-plugin.version}</version>
                 <configuration>
                     <excludedGroups>slow</excludedGroups>
                     <includes>
@@ -198,7 +198,7 @@
             <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>
                 <artifactId>gmavenplus-plugin</artifactId>
-                <version>4.3.1</version>
+                <version>${gmavenplus-plugin.version}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -213,7 +213,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>${build-helper-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>add-test-source</id>
@@ -364,7 +364,7 @@
 
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/workbenchfx-core/pom.xml
+++ b/workbenchfx-core/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.dlsc.workbenchfx</groupId>
         <artifactId>workbenchfx-parent</artifactId>
-        <version>17.0.0</version>
+        <version>21.0.0</version>
     </parent>
 
     <artifactId>workbenchfx-core</artifactId>
@@ -170,7 +170,7 @@
             <!-- Execute Tests (JUnit / Spock) -->
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M5</version>
+                <version>3.5.3</version>
                 <configuration>
                     <excludedGroups>slow</excludedGroups>
                     <includes>
@@ -198,7 +198,7 @@
             <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>
                 <artifactId>gmavenplus-plugin</artifactId>
-                <version>1.13.1</version>
+                <version>4.3.1</version>
                 <executions>
                     <execution>
                         <goals>

--- a/workbenchfx-core/src/test/groovy/com/dlsc/workbenchfx/WorkbenchSpec.groovy
+++ b/workbenchfx-core/src/test/groovy/com/dlsc/workbenchfx/WorkbenchSpec.groovy
@@ -97,7 +97,7 @@ class WorkbenchSpec extends ApplicationSpec {
         }
 
         for (int i = 0; i < mockModules.length; i++) {
-            mockModules[i] = createMockModule(moduleNodes[i], null, true, "Module " + i)
+            mockModules[i] = createMockModule(moduleNodes[i], true, "Module " + i)
         }
 
         FontIcon FontIcon = new FontIcon(MaterialDesign.MDI_CALENDAR_QUESTION)
@@ -255,16 +255,16 @@ class WorkbenchSpec extends ApplicationSpec {
      *
      * @param displayNode node to be displayed in the mock
      * @param destroy what the call for {@link WorkbenchModule#destroy()} should return
-     * @param toString what {@link WorkbenchModule#toString()} should return
+     * @param name the name of the module, also returned by {@link WorkbenchModule#toString()}
      * @return the mock
      */
-    def createMockModule(Node displayNode, Node icon, boolean destroy, String toString) {
-        WorkbenchModule mockModule = Mock(WorkbenchModule.class)
-        mockModule.getName() >> toString
-        mockModule.getIcon() >> icon
+    def createMockModule(Node displayNode, boolean destroy, String name) {
+        // getName() and getIcon() are final and can therefore not be stubbed. The name is passed
+        // to the real constructor instead, which is where WorkbenchModule takes it from.
+        WorkbenchModule mockModule = Mock(constructorArgs: [name, (Image) null], WorkbenchModule)
         mockModule.activate() >> displayNode
         mockModule.destroy() >> destroy
-        mockModule.toString() >> toString
+        mockModule.toString() >> name
         return mockModule
     }
 

--- a/workbenchfx-core/src/test/groovy/com/dlsc/workbenchfx/view/controls/selectionstrip/SelectionStripSpec.groovy
+++ b/workbenchfx-core/src/test/groovy/com/dlsc/workbenchfx/view/controls/selectionstrip/SelectionStripSpec.groovy
@@ -57,7 +57,7 @@ class SelectionStripSpec extends ApplicationSpec {
 
         then: "cellfactory is instance of StripCell"
         null != selectionStrip.getCellFactory()
-        selectionStrip.getCellFactory() instanceof Callback<SelectionStrip, StripCell<WorkbenchModule>>
+        selectionStrip.getCellFactory() instanceof Callback
     }
 
     @Unroll

--- a/workbenchfx-demo/README.md
+++ b/workbenchfx-demo/README.md
@@ -6,7 +6,7 @@ straight from Maven.
 
 ## Prerequisites
 
-* JDK 17 (the parent POM sets `java.version` to 17)
+* JDK 21 (the parent POM sets `java.version` to 21)
 * A desktop/display — these are GUI applications and will not start headless
 * No separate JavaFX SDK needed; the OpenJFX artifacts come in as Maven dependencies
 
@@ -30,8 +30,8 @@ Once `workbenchfx-core` is in your local repository, changes confined to this mo
 > **Note:** the `install` step is required because the demo is launched in a separate Maven
 > invocation whose reactor contains only this module, so `workbenchfx-core` is resolved as an
 > external artifact from `~/.m2`. A `verify` build stops at `target/` and publishes nothing there.
-> The current version `17.0.0` is not on Maven Central yet, so skipping `install` fails outright
-> with `com.dlsc.workbenchfx:workbenchfx-core:jar:17.0.0 (absent)` rather than silently using a
+> The current version `21.0.0` is not on Maven Central yet, so skipping `install` fails outright
+> with `com.dlsc.workbenchfx:workbenchfx-core:jar:21.0.0 (absent)` rather than silently using a
 > stale jar.
 
 > **Note:** do not add `-am`. Maven applies a command-line goal to every module in the reactor
@@ -60,6 +60,42 @@ For example, to run the FXML demo:
 
 Each demo class has a `main` method, so you can also just run it directly from your IDE
 after importing the root `pom.xml` as a Maven project.
+
+## Known issues
+
+### WebView modules that open a WebSocket fail on JavaFX 21.0.3 and later
+
+Opening the *JFX-Central* module (`SimpleDemo`, `ExtendedDemo`, `CustomDemo`) throws:
+
+```
+java.lang.UnsatisfiedLinkError: 'void com.sun.webkit.network.SocketStreamHandle.twkDidOpen(long)'
+```
+
+`https://jfx-central.com` is a Vaadin application and therefore opens a WebSocket, which is
+what triggers this. Any WebView page using WebSockets is affected.
+
+This is an upstream JavaFX problem, not a WorkbenchFX one. From JavaFX 21.0.3 onwards the
+bundled `libjfxwebkit.so` no longer implements the `SocketStreamHandle` native methods, while
+`com.sun.webkit.network.SocketStreamHandle` still declares and calls them. Counting the
+`Java_com_sun_webkit_network_SocketStreamHandle_twk*` symbols exported by the native library:
+
+| `javafx-web` | Exported symbols | WebView WebSockets |
+|--------------|------------------|--------------------|
+| 17.0.1       | 4                | work               |
+| 21.0.1       | 4                | work               |
+| 21.0.2       | 4                | work — last good release in the 21 line |
+| 21.0.3 … 21.0.12 | 0            | broken             |
+| 26.0.2       | 0                | broken             |
+
+Since the problem is still present in the newest JavaFX line, upgrading does not help. If you
+need WebSockets in a WebView, build against JavaFX 21.0.2:
+
+```bash
+./mvnw -pl workbenchfx-demo compile exec:java@simple-demo -Djavafx.version=21.0.2
+```
+
+Note that 21.0.2 predates the WebKit fixes shipped in later patch releases, so this is a
+workaround for local experimentation rather than a recommendation for production.
 
 ## Source layout
 

--- a/workbenchfx-demo/README.md
+++ b/workbenchfx-demo/README.md
@@ -1,0 +1,72 @@
+# WorkbenchFX Demos
+
+Runnable JavaFX applications showcasing WorkbenchFX. Each demo is wired up as an
+`exec-maven-plugin` execution in this module's `pom.xml`, so you can start any of them
+straight from Maven.
+
+## Prerequisites
+
+* JDK 17 (the parent POM sets `java.version` to 17)
+* A desktop/display — these are GUI applications and will not start headless
+* No separate JavaFX SDK needed; the OpenJFX artifacts come in as Maven dependencies
+
+## Running a demo
+
+All commands are run from the **repository root** using the Maven wrapper.
+
+On a fresh clone — and whenever you change `workbenchfx-core` — build and install the whole
+project first, then launch the demo:
+
+```bash
+./mvnw install -DskipTests && ./mvnw -pl workbenchfx-demo exec:java@custom-demo
+```
+
+Once `workbenchfx-core` is in your local repository, changes confined to this module only need:
+
+```bash
+./mvnw -pl workbenchfx-demo compile exec:java@custom-demo
+```
+
+> **Note:** the `install` step is required because the demo is launched in a separate Maven
+> invocation whose reactor contains only this module, so `workbenchfx-core` is resolved as an
+> external artifact from `~/.m2`. A `verify` build stops at `target/` and publishes nothing there.
+> The current version `17.0.0` is not on Maven Central yet, so skipping `install` fails outright
+> with `com.dlsc.workbenchfx:workbenchfx-core:jar:17.0.0 (absent)` rather than silently using a
+> stale jar.
+
+> **Note:** do not add `-am`. Maven applies a command-line goal to every module in the reactor
+> and falls back to the plugin's default configuration where the execution id is missing, so
+> the build fails on `workbenchfx-core` with `The parameters 'mainClass' ... are missing or invalid`.
+
+## Available demos
+
+Replace the execution id in the commands above with any of the following:
+
+| Execution id         | Main class          | What it shows                                                                                 |
+|----------------------|---------------------|-----------------------------------------------------------------------------------------------|
+| `simple-demo`        | `SimpleDemo`        | Minimal setup: a `Workbench` with a handful of modules (calendar, hello world, maps, web).      |
+| `extended-demo`      | `ExtendedDemo`      | Adds toolbars, menus, drawers, dialogs and a PreferencesFX-backed settings module.              |
+| `custom-demo`        | `CustomDemo`        | Full customisation — custom page, tab, tile factories, navigation drawer and overlays.           |
+| `fxml-demo`          | `FXMLDemo`          | Declaring the `Workbench` in FXML (`workbench.fxml` + `FXMLController`), e.g. with [Scene Builder](https://gluonhq.com/products/scene-builder/). |
+| `single-module-demo` | `SingleModuleDemo`  | A `Workbench` with a single module, which hides the tab bar.                                     |
+
+For example, to run the FXML demo:
+
+```bash
+./mvnw -pl workbenchfx-demo compile exec:java@fxml-demo
+```
+
+## Running from an IDE
+
+Each demo class has a `main` method, so you can also just run it directly from your IDE
+after importing the root `pom.xml` as a Maven project.
+
+## Source layout
+
+```
+src/main/java/com/dlsc/workbenchfx/demo/
+├── *Demo.java     — the launchable applications listed above
+├── controls/      — custom controls and skins used by CustomDemo
+└── modules/       — the WorkbenchModule implementations (calendar, maps, patient,
+                     preferences, webview, helloworld, test modules)
+```

--- a/workbenchfx-demo/pom.xml
+++ b/workbenchfx-demo/pom.xml
@@ -15,6 +15,10 @@
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
+
+        <!-- Only used by the demo -->
+        <cssfx.version>11.5.1</cssfx.version>
+        <exec-maven-plugin.version>3.6.3</exec-maven-plugin.version>
     </properties>
 
     <build>
@@ -22,7 +26,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>${maven-source-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -36,7 +40,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>${maven-compiler-plugin.version}</version>
                 <configuration>
                     <release>${java.version}</release>
                     <source>${java.version}</source>
@@ -47,7 +51,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>${exec-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>custom-demo</id>
@@ -107,7 +111,7 @@
         <dependency>
             <groupId>fr.brouillard.oss</groupId>
             <artifactId>cssfx</artifactId>
-            <version>11.4.0</version>
+            <version>${cssfx.version}</version>
         </dependency>
 
         <dependency>
@@ -133,7 +137,7 @@
 
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
         </dependency>
 
         <!-- Libraries -->

--- a/workbenchfx-demo/pom.xml
+++ b/workbenchfx-demo/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.dlsc.workbenchfx</groupId>
         <artifactId>workbenchfx-parent</artifactId>
-        <version>21.0.0</version>
+        <version>25.0.0</version>
     </parent>
 
     <artifactId>workbenchfx-demo</artifactId>

--- a/workbenchfx-demo/pom.xml
+++ b/workbenchfx-demo/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.dlsc.workbenchfx</groupId>
         <artifactId>workbenchfx-parent</artifactId>
-        <version>17.0.0</version>
+        <version>21.0.0</version>
     </parent>
 
     <artifactId>workbenchfx-demo</artifactId>

--- a/workbenchfx-demo/pom.xml
+++ b/workbenchfx-demo/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.dlsc.workbenchfx</groupId>
         <artifactId>workbenchfx-parent</artifactId>
-        <version>11.3.1</version>
+        <version>17.0.0</version>
     </parent>
 
     <artifactId>workbenchfx-demo</artifactId>
@@ -38,8 +38,9 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <release>${java.version}</release>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
## PR Checklist

- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open an issue first and wait for approval before working on it.
- [x] The code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html).
- [-] JavaDoc is added / changed for public methods. => NOT CHANGED
- [-] An example of the new feature is added to the [demos](https://github.com/dlemmermann/WorkbenchFX/tree/master/workbenchfx-demo/src/main/java/com/dlsc/workbenchfx). => NOT CHANGED
- [x] Documentation of the feature is included in the [README](https://github.com/dlemmermann/WorkbenchFX/blob/master/README.md).
- [-] Tests for the changes are included. => NOT CHANGED

## What is the current behavior?
Last version with issue #618 was Java 21/JavaFX 21

## What is the new behavior?
Now we're on Java 25/JavaFX 26

Fixes #620

## Breaking Change:
Using apps will require to run on Java 25 or later.
